### PR TITLE
Make delimiter choice explicit and mutually exclusive; add 'isExecutable' property

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // © MIT license
 
 const { parseNestedQuotes } = require('./lib/split')
-const { reduceQuoteDepth, splitNestedQuotes, flattenNestedQuotes } = require('./lib/split/quotes')
+const { reduceQuoteDepth, splitNestedQuotes, flattenNestedQuotes, combineEscapedSpaces } = require('./lib/split/quotes')
 const { unpackCombinedOptionsList } = require('./lib/arguments/meta')
 const { parseCommand, splitCommand } = require('./lib')
 
@@ -11,6 +11,7 @@ module.exports = {
   splitCommand,
   util: {
     reduceQuoteDepth,
+    combineEscapedSpaces,
     flattenNestedQuotes,
     parseNestedQuotes,
     splitNestedQuotes,

--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@
 const { parseNestedQuotes } = require('./lib/split')
 const { reduceQuoteDepth, splitNestedQuotes, flattenNestedQuotes, combineEscapedSpaces } = require('./lib/split/quotes')
 const { unpackCombinedOptionsList } = require('./lib/arguments/meta')
-const { parseCommand, splitCommand } = require('./lib')
+const { parseCommand, splitCommand, parseArguments, splitArguments } = require('./lib')
 
 module.exports = {
   parseCommand,
   splitCommand,
+  parseArguments,
+  splitArguments,
   util: {
     reduceQuoteDepth,
     combineEscapedSpaces,

--- a/lib/arguments/index.js
+++ b/lib/arguments/index.js
@@ -19,9 +19,11 @@ const unpackCombinedOptions = (args, options, format) => {
 const makeArgumentMetadata = (args, options, format) => {
   const items = []
   let afterTerminator = false
-  for (const arg of args) {
+  for (let n = 0; n < args.length; ++n) {
+    const isExec = n === 0 && options.firstIsExec
+    const arg = args[n]
     // Note: this returns an array, as a single argument can be unpacked to multiple ones.
-    const meta = argumentMetadata(arg, options, format, afterTerminator)
+    const meta = argumentMetadata(arg, options, format, isExec, afterTerminator)
 
     // If we've stumbled upon the terminator, stop processing options
     // and treat everything as a regular argument from here on.

--- a/lib/arguments/meta.js
+++ b/lib/arguments/meta.js
@@ -4,8 +4,8 @@
 /**
  * Checks whether the current argument is a terminator.
  */
-const findTerminator = (arg, terminatorString, afterTerminator = false, useTerminator = true) => {
-  if (afterTerminator || !useTerminator) return false
+const findTerminator = (arg, terminatorString, isExec, afterTerminator = false, useTerminator = true) => {
+  if (isExec || afterTerminator || !useTerminator) return false
   return arg === terminatorString
 }
 
@@ -14,11 +14,11 @@ const findTerminator = (arg, terminatorString, afterTerminator = false, useTermi
  * 
  * This takes the result of findPrefix(), as only options can have a suffix.
  */
-const findSuffix = (prefix, suffixes, afterTerminator = false) => {
+const findSuffix = (prefix, suffixes, isExec = false, afterTerminator = false) => {
   let suffix = null
   let remainder = prefix.remainder
 
-  if (!afterTerminator && prefix.metadata.isOption) {
+  if (!afterTerminator && !isExec && prefix.metadata.isOption) {
     for (const suffixItem of suffixes) {
       const suffixRe = new RegExp(`^([^${suffixItem}]*)(${suffixItem})$`)
       const matches = prefix.remainder.match(suffixRe)
@@ -40,7 +40,7 @@ const findSuffix = (prefix, suffixes, afterTerminator = false) => {
 /**
  * Returns data about any prefix that might be part of this argument.
  */
-const findPrefix = (arg, prefixes, afterTerminator = false) => {
+const findPrefix = (arg, prefixes, isExec = false, afterTerminator = false) => {
   let prefixType = null
   let isCombinable = null
   let prefix = null
@@ -48,7 +48,7 @@ const findPrefix = (arg, prefixes, afterTerminator = false) => {
   let isOption = false
   let remainder = arg
 
-  if (!afterTerminator) {
+  if (!afterTerminator && !isExec) {
     for (const prefixItem of prefixes) {
       const matches = arg.match(prefixItem.re)
       if (matches == null || matches[2] === '') {
@@ -81,8 +81,8 @@ const argumentIsOption = (item, format, afterTerminator = false) => {
 /**
  * Checks whether an argument is a combined option, e.g. "-ab" meaning "-a" and "-b".
  */
-const checkCombinability = (value, prefix, afterTerminator = false, useCombining = true) => {
-  return !afterTerminator && useCombining && prefix.isCombinable === true && !prefix.metadata.isLongOption && value.length > 1
+const checkCombinability = (value, prefix, isExec, afterTerminator, useCombining = true) => {
+  return !isExec && !afterTerminator && useCombining && prefix.isCombinable === true && !prefix.metadata.isLongOption && value.length > 1
 }
 
 /**
@@ -92,13 +92,15 @@ const unpackCombinedOptionsList = (args, options, format) => {
   const items = []
   let afterTerminator = false
 
-  for (const arg of args) {
-    const isTerminator = findTerminator(arg, format.optionsTerminator, afterTerminator, options.useOptionsTerminator)
+  for (let n = 0; n < args.length; ++n) {
+    const arg = args[n]
+    const isExec = n === 0 && options.firstIsExec
+    const isTerminator = findTerminator(arg, format.optionsTerminator, isExec, afterTerminator, options.useOptionsTerminator)
     const prefix = findPrefix(arg, format.valuePrefix, afterTerminator || isTerminator)
     const suffix = findSuffix(prefix, format.valueSuffix, afterTerminator || isTerminator)
     const value = suffix.remainder
 
-    if (checkCombinability(value, prefix, afterTerminator || isTerminator, options.unpackCombinedOptions)) {
+    if (checkCombinability(value, prefix, isExec, afterTerminator || isTerminator, options.unpackCombinedOptions)) {
       const prefixChar = prefix.metadata.prefix || ''
       const suffixChar = suffix.metadata.suffix || ''
       for (let n = 0; n < value.length; ++n) {
@@ -144,11 +146,11 @@ const unpackCombinedOptions = (argObject, isCombinedOption) => {
 /**
  * Converts an argument string into an object that has more extensive information.
  */
-const argumentMetadata = (arg, options, format, afterTerminator = false) => {
-  const isTerminator = findTerminator(arg, format.optionsTerminator, afterTerminator, options.useOptionsTerminator)
+const argumentMetadata = (arg, options, format, isExec, afterTerminator) => {
+  const isTerminator = findTerminator(arg, format.optionsTerminator, isExec, afterTerminator, options.useOptionsTerminator)
   const noOption = isTerminator || afterTerminator
-  const prefix = findPrefix(arg, format.valuePrefix, noOption)
-  const suffix = findSuffix(prefix, format.valueSuffix, noOption)
+  const prefix = findPrefix(arg, format.valuePrefix, isExec, noOption)
+  const suffix = findSuffix(prefix, format.valueSuffix, isExec, noOption)
   const value = suffix.remainder
 
   // If this is an option with a suffix, it will take the next argument as its content.
@@ -158,7 +160,7 @@ const argumentMetadata = (arg, options, format, afterTerminator = false) => {
   // Unix style options can be combined, e.g. "-ab" meaning two options named "-a" and "-b".
   // At the same time, some programs (like ffmpeg) do not use combined options, and "-ab"
   // simply means one option named "ab". We parse these either way.
-  const isCombinedOption = checkCombinability(value, prefix, noOption, options.unpackCombinedOptions)
+  const isCombinedOption = checkCombinability(value, prefix, isExec, noOption, options.unpackCombinedOptions)
 
   const argObject = {
     value,
@@ -166,6 +168,7 @@ const argumentMetadata = (arg, options, format, afterTerminator = false) => {
     ...suffix.metadata,
     isPaired,
     isTerminator,
+    isExecutable: isExec,
     afterTerminator,
     originalValue: arg
   }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -5,6 +5,8 @@
 const defaultOptions = {
   // Whether to scan for Windows style slash delimiters.
   useWindowsDelimiters: false,
+  // Ensures that the first item is treated like the executable path.
+  firstIsExec: true,
   // Transforms combined options into individual options (e.g. -asdf into -a -s -d -f).
   unpackCombinedOptions: true,
   // Preserves the quotes, instead of removing one layer of depth from them.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,24 +18,34 @@ const defaultOptions = {
 
 /** The format used to unpack argument metadata. */
 const defaultFormat = {
-  valuePrefix: [
-    { type: 'unix', re: /^(-+)(.*)$/, isCombinable: true },
-    { type: 'windows', re: /^(\/+)(.*)$/, isCombinable: true }
-  ],
   // If an argument ends with a value suffix, it takes at least one value.
   valueSuffix: ['=', ':'],
   // This argument, when encountered, terminates all options;
   // everything from that point is a regular argument even if it contains a prefix.
+  // Used on Unix systems only.
   optionsTerminator: '--'
+}
+
+/** Delimiters used to separate values. */
+const valueDelimiters = {
+  unix: [{ re: /^(-+)(.*)$/, isCombinable: true }],
+  windows: [{ re: /^(\/+)(.*)$/, isCombinable: true }]
 }
 
 /**
  * Takes the user's options and format and returns them with the defaults merged in.
  */
 const mergeDefaults = (userOptions = {}, userFormat = {}) => {
+  const options = { ...defaultOptions, ...userOptions }
+  const format = { ...defaultFormat, ...userFormat }
+
+  // Pick a set of value delimiters based on the platform.
+  const platform = options.useWindowsDelimiters ? 'windows' : 'unix'
+  format.valuePrefix = valueDelimiters[platform].map(delimiter => ({ ...delimiter, type: platform }))
+  
   return {
-    options: { ...defaultOptions, ...userOptions },
-    format: { ...defaultFormat, ...userFormat }
+    options,
+    format
   }
 }
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,8 @@
 
 /** The default parsing options. */
 const defaultOptions = {
+  // Whether to scan for Windows style slash delimiters.
+  useWindowsDelimiters: false,
   // Transforms combined options into individual options (e.g. -asdf into -a -s -d -f).
   unpackCombinedOptions: true,
   // Preserves the quotes, instead of removing one layer of depth from them.

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -8,7 +8,7 @@ const defaultOptions = {
   // Ensures that the first item is treated like the executable path.
   firstIsExec: true,
   // Transforms combined options into individual options (e.g. -asdf into -a -s -d -f).
-  unpackCombinedOptions: true,
+  unpackCombinedOptions: false,
   // Preserves the quotes, instead of removing one layer of depth from them.
   preserveQuotes: false,
   // Whether to use or ignore the terminator option.

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,23 @@ const parseCommand = (command, userOptions, userFormat) => {
   }
 }
 
+/**
+ * Alias for parseCommand(), with 'firstIsExec' always false.
+ */
+const parseArguments = (argumentList, userOptions, userFormat) => {
+  return parseCommand(argumentList, { ...userOptions, firstIsExec: false }, userFormat)
+}
+
+/**
+ * Alias for splitCommand(), with 'firstIsExec' always false.
+ */
+const splitArguments = (argumentList, userOptions, userFormat) => {
+  return splitCommand(argumentList, { ...userOptions, firstIsExec: false }, userFormat)
+}
+
 module.exports = {
   parseCommand,
-  splitCommand
+  splitCommand,
+  parseArguments,
+  splitArguments
 }

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,7 +1,8 @@
 const { splitCommand, parseCommand } = require('./index')
 
 // Returns a parsed argument object's default values.
-const arg = (arg, overrides = {}) => ({ value: arg, prefix: null, prefixType: null, isLongOption: false, isOption: false, suffix: null, isPaired: false, isTerminator: false, afterTerminator: false, originalValue: arg, isUnpacked: false, ...overrides })
+const arg = (arg, overrides = {}) => ({ value: arg, prefix: null, prefixType: null, isExecutable: false, isLongOption: false, isOption: false, suffix: null, isPaired: false, isTerminator: false, afterTerminator: false, originalValue: arg, isUnpacked: false, ...overrides })
+const exec = (value, overrides = {}) => ({ ...arg(value, { isExecutable: true, ...overrides }) })
 const shortOpt = (value, overrides = {}) => ({ ...arg(value, { isOption: true, prefix: '-', originalValue: `-${value}`, prefixType: 'unix', ...overrides }) })
 const shortOptW = (value, overrides = {}) => ({ ...arg(value, { isOption: true, prefix: '/', originalValue: `/${value}`, prefixType: 'windows', ...overrides }) })
 const longOpt = (value, overrides = {}) => ({ ...arg(value, { isOption: true, isLongOption: true, prefix: '--', originalValue: `--${value}`, prefixType: 'unix', ...overrides }) })
@@ -47,12 +48,12 @@ describe(`cmd-tokenize package`, () => {
         input: 'run_program',
         inputSplit: ['run_program'],
         arguments: [
-          arg('run_program')
+          exec('run_program')
         ],
         options: {}
       })
       expect(parseCommand(`run_program hello world "hello world" -a -a -b -b --a sadf  -n asdf  --some_value="something" --another-value="some thing" --yet_another_value="a  \\"quoted value\\""  --a --b --z="dsf" -asdf --d=\\"sdf\\" --d = - -- --zap --sdf`).arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         arg('hello'),
         arg('world'),
         arg('hello world'),
@@ -89,14 +90,14 @@ describe(`cmd-tokenize package`, () => {
       ])
       expect(parseCommand(``).arguments).toMatchObject([])
       expect(parseCommand(`asdf --asdf="" " zxcv " " qwer\\" wer \\" "`).arguments).toMatchObject([
-        arg('asdf'),
+        exec('asdf'),
         longOpt('asdf', { isPaired: true, suffix: '=', originalValue: '--asdf=' }),
         arg(''),
         arg(' zxcv '),
         arg(` qwer" wer " `)
       ])
       expect(parseCommand(`program arg --another-arg -a -asdf --with-value="value" -- --after-terminator`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('arg'),
         longOpt('another-arg'),
         shortOpt('a'),
@@ -110,7 +111,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--after-terminator', { afterTerminator: true })
       ])
       expect(parseCommand(`run_program arg "another arg" "an arg with \\"nested and \\\\"super nested\\\\" quotes\\"" --a --b -asdf --z="hello" --empty="" -a="b" -abc="d" - = --quotes="quotes 'inner \\"more inner quotes\\" quotes'" -- --post-terminator -asdf -a -b`).arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         arg('arg'),
         arg('another arg'),
         arg(`an arg with "nested and \\"super nested\\" quotes"`),
@@ -141,13 +142,13 @@ describe(`cmd-tokenize package`, () => {
         arg('-b', { afterTerminator: true })
       ])
       expect(parseCommand(`a bb=cc cc=a"b"c"d" dd="ee"`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('bb=cc'),
         arg('cc=abcd'),
         arg('dd=ee')
       ])
       expect(parseCommand(`a bb=a"b"c"d" z "y" - = -a="d" -a=a=b=c`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('bb=abcd'),
         arg('z'),
         arg('y'),
@@ -159,12 +160,12 @@ describe(`cmd-tokenize package`, () => {
         arg('a=b=c')
       ])
       expect(parseCommand(`a -c:v`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('c', { isPaired: true, suffix: ':', originalValue: '-c:' }),
         arg('v')
       ])
       expect(parseCommand(`a --asdf=zxcv=asdf --a="a"b"c"d"e"f" --program title=string:st=number b -- asdf --asdf=zxcv=asdf`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, suffix: '=', originalValue: '--asdf=' }),
         arg('zxcv=asdf'),
         longOpt('a', { isPaired: true, suffix: '=', originalValue: '--a=' }),
@@ -177,50 +178,51 @@ describe(`cmd-tokenize package`, () => {
         arg('--asdf=zxcv=asdf', { afterTerminator: true })
       ])
       expect(parseCommand(`a "b" "c\\"d\\\\"e\\\\"\\"" "" f`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('b'),
         arg(`c"d\\"e\\""`),
         arg(''),
         arg('f')
       ])
       expect(parseCommand(`a --b:"c"`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('b', { suffix: ':', isPaired: true, originalValue: '--b:' }),
         arg('c')
       ])
-      expect(parseCommand(`--program --title=string:st=number`).arguments).toMatchObject([
+      expect(parseCommand(`program --program --title=string:st=number`).arguments).toMatchObject([
+        exec('program'),
         longOpt('program'),
         longOpt('title', { suffix: '=', isPaired: true, originalValue: '--title=' }),
         arg('string:st=number')
       ])
       expect(parseCommand(`a "a" "a\\"asdf b`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('a'),
         arg('"a\\"asdf'),
         arg('b')
       ])
       expect(parseCommand(`command \\"zxcv" something`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('command'),
+        exec('command'),
         arg('\\"zxcv"'),
         arg('something')
       ])
       expect(parseCommand(`command "asdf "xcv dfs`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('command'),
+        exec('command'),
         arg(`asdf xcv`),
         arg('dfs')
       ])
       expect(parseCommand(`command "asdf\\"xcv dfs`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('command'),
+        exec('command'),
         arg(`"asdf\\"xcv`),
         arg('dfs')
       ])
       expect(parseCommand(`command "asdf\\"xcv" dfs`, { throwOnUnbalancedQuote: true }).arguments).toMatchObject([
-        arg('command'),
+        exec('command'),
         arg(`asdf"xcv`),
         arg('dfs')
       ])
       expect(parseCommand(`a --asdf="" --asdf=a=""  --asdf=a="b" --asdf=a=\\"b\\" b`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, suffix: '=', originalValue: '--asdf=' }),
         arg(''),
         longOpt('asdf', { isPaired: true, suffix: '=', originalValue: '--asdf=' }),
@@ -231,7 +233,8 @@ describe(`cmd-tokenize package`, () => {
         arg('a=\\"b\\"'),
         arg('b')
       ])
-      expect(parseCommand(`-a= --asdf=a="" --zxcv=""`).arguments).toMatchObject([
+      expect(parseCommand(`prog -a= --asdf=a="" --zxcv=""`).arguments).toMatchObject([
+        exec('prog'),
         shortOpt('a', { isPaired: true, suffix: '=', originalValue: '-a=' }),
         arg(''),
         longOpt('asdf', { isPaired: true, suffix: '=', originalValue: '--asdf=' }),
@@ -240,16 +243,16 @@ describe(`cmd-tokenize package`, () => {
         arg('')
       ])
       expect(parseCommand(`a --arg""`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('arg')
       ])
       expect(parseCommand(`a --a==`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('a', { isPaired: true, suffix: '=', originalValue: '--a=' }),
         arg('=')
       ])
       expect(parseCommand(`a "a" 'a' '\\'b\\"b\\"b\\''`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('a'),
         arg('a'),
         arg(`'b\\"b\\"b'`)
@@ -257,47 +260,48 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`parses arguments`, () => {
       expect(parseCommand('run_program').arguments).toMatchObject([
-        arg('run_program')
+        exec('run_program')
       ])
     })
     it(`parses short options`, () => {
       expect(parseCommand('run_program -a').arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         shortOpt('a')
       ])
       expect(parseCommand('run_program -a -b').arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         shortOpt('a'),
         shortOpt('b')
       ])
     })
     it(`parses long options`, () => {
       expect(parseCommand('run_program --asdf').arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         longOpt('asdf')
       ])
       expect(parseCommand('run_program --asdf --zxcv').arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         longOpt('asdf'),
         longOpt('zxcv')
       ])
     })
     it(`parses empty quotes as empty strings`, () => {
       expect(parseCommand('a "" "a"').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg(''),
         arg('a')
       ])
       expect(parseCommand('a --arg=""').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('arg', { isPaired: true, originalValue: '--arg=', suffix: '=' }),
         arg('')
       ])
       expect(parseCommand('a --arg""').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('arg')
       ])
-      expect(parseCommand(`-a= --asdf=a="" --zxcv=""`).arguments).toMatchObject([
+      expect(parseCommand(`prog -a= --asdf=a="" --zxcv=""`).arguments).toMatchObject([
+        exec('prog'),
         shortOpt('a', { isPaired: true, originalValue: '-a=', suffix: '=' }),
         arg(''),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
@@ -308,7 +312,7 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`parses -, = and : as distinct non-option arguments`, () => {
       expect(parseCommand(`a - b = c : d`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('-'),
         arg('b'),
         arg('='),
@@ -317,92 +321,92 @@ describe(`cmd-tokenize package`, () => {
         arg('d')
       ])
       expect(parseCommand(`a --a =`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('a'),
         arg('=')
       ])
       expect(parseCommand(`a --a==`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('a', { isPaired: true, suffix: '=', originalValue: '--a=' }),
         arg('=')
       ])
     })
     it(`preserves -, = and : literally inside non-option arguments`, () => {
       expect(parseCommand(`program --asdf-zxcv`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         longOpt('asdf-zxcv')
       ])
       expect(parseCommand(`program --asdf--zxcv`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         longOpt('asdf--zxcv')
       ])
       expect(parseCommand(`program --asdf="zx:cv"`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         longOpt('asdf', { isPaired: true, suffix: '=', originalValue: '--asdf=' }),
         arg('zx:cv'),
       ])
       expect(parseCommand(`program asdf-zxcv`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('asdf-zxcv')
       ])
       expect(parseCommand(`program asdf--zxcv`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('asdf--zxcv')
       ])
       expect(parseCommand(`program asdf=zxcv`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('asdf=zxcv')
       ])
       expect(parseCommand(`program asdf:zxcv`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('asdf:zxcv')
       ])
       expect(parseCommand(`program asdf="zxcv"`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('asdf=zxcv')
       ])
     })
     it(`preserves arguments enclosed in double quotes verbatim`, () => {
       expect(parseCommand('a -abc').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' })
       ])
       expect(parseCommand('a "-abc"').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' })
       ])
       expect(parseCommand(`a "'-abc'"`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg(`'-abc'`)
       ])
       expect(parseCommand(`a '"-abc"'`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg(`"-abc"`)
       ])
       expect(parseCommand(`a --hello`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt(`hello`)
       ])
       expect(parseCommand(`a "--hello"`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt(`hello`)
       ])
       expect(parseCommand(`a "'--hello'"`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg(`'--hello'`)
       ])
       expect(parseCommand(`a '"--hello"'`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg(`"--hello"`)
       ])
     })
     it(`parses Windows style options when 'useWindowsDelimiters' is true`, () => {
       expect(parseCommand('a /aaa /c /d /zxcv', { useWindowsDelimiters: true }).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
@@ -416,40 +420,40 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`pairs options with their next value if a suffix is present`, () => {
       expect(parseCommand('a --asdf=a').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
         arg('a')
       ])
       expect(parseCommand('a --asdf="a"').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
         arg('a')
       ])
       expect(parseCommand('a --asdf="" a').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
         arg(''),
         arg('a')
       ])
       expect(parseCommand('a --asdf:a').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf:', suffix: ':' }),
         arg('a')
       ])
       expect(parseCommand('a -c:v').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('c', { isPaired: true, originalValue: '-c:', suffix: ':' }),
         arg('v')
       ])
       expect(parseCommand('a -c:"v"').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('c', { isPaired: true, originalValue: '-c:', suffix: ':' }),
         arg('v')
       ])
     })
     it(`unpacks short arguments`, () => {
       expect(parseCommand('a -a -bc -def').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a'),
         shortOpt('b', { originalValue: '-bc', isUnpacked: true }),
         shortOpt('c', { originalValue: '-bc', isUnpacked: true }),
@@ -458,7 +462,7 @@ describe(`cmd-tokenize package`, () => {
         shortOpt('f', { originalValue: '-def', isUnpacked: true })
       ])
       expect(parseCommand('a --a -abc --d').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('a'),
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
@@ -466,14 +470,14 @@ describe(`cmd-tokenize package`, () => {
         longOpt('d')
       ])
       expect(parseCommand('a -abc="d"').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a', { originalValue: '-abc=', suffix: '=', isPaired: false, isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc=', suffix: '=', isPaired: false, isUnpacked: true }),
         shortOpt('c', { originalValue: '-abc=', suffix: '=', isPaired: true, isUnpacked: true }),
         arg('d')
       ])
       expect(parseCommand('a -abc -- -abc').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('c', { originalValue: '-abc', isUnpacked: true }),
@@ -481,7 +485,7 @@ describe(`cmd-tokenize package`, () => {
         arg('-abc', { afterTerminator: true })
       ])
       expect(parseCommand(`a  -abcd="z"   --a -- -zxcv`).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a', { originalValue: '-abcd=', isUnpacked: true, suffix: '=' }),
         shortOpt('b', { originalValue: '-abcd=', isUnpacked: true, suffix: '=' }),
         shortOpt('c', { originalValue: '-abcd=', isUnpacked: true, suffix: '=' }),
@@ -494,14 +498,14 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`stops processing options after a terminator argument`, () => {
       expect(parseCommand('run_program -a -b -- -c').arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         shortOpt('a'),
         shortOpt('b'),
         arg('--', { isTerminator: true }),
         arg('-c', { afterTerminator: true })
       ])
       expect(parseCommand('run_program -a --asdf -- --zxcv').arguments).toMatchObject([
-        arg('run_program'),
+        exec('run_program'),
         shortOpt('a'),
         longOpt('asdf'),
         arg('--', { isTerminator: true }),
@@ -510,13 +514,13 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`preserves spaces in quotes`, () => {
       expect(parseCommand(`something " something " --asdf=" z "`).arguments).toMatchObject([
-        arg('something'),
+        exec('something'),
         arg(' something '),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
         arg(' z ')
       ])
       expect(parseCommand(`something " something \\" else \\"  " --asdf=" \\"z\\" "`).arguments).toMatchObject([
-        arg('something'),
+        exec('something'),
         arg(' something " else "  '),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
         arg(' "z" ')
@@ -524,92 +528,92 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`preserves escaped spaces outside of quotes`, () => {
       expect(parseCommand(`foo\\ bar baz`).arguments).toMatchObject([
-        arg('foo bar'),
+        exec('foo bar'),
         arg('baz')
       ])
       expect(parseCommand(`foo\\ bar\\ baz`).arguments).toMatchObject([
-        arg('foo bar baz')
+        exec('foo bar baz')
       ])
       expect(parseCommand(`foo\\ bar\\ baz bap`).arguments).toMatchObject([
-        arg('foo bar baz'),
+        exec('foo bar baz'),
         arg('bap')
       ])
       expect(parseCommand(`foo\\ bar\\ "baz"`).arguments).toMatchObject([
-        arg('foo bar baz')
+        exec('foo bar baz')
       ])
       expect(parseCommand(`foo\\ bar\\ "baz"`, { preserveQuotes: true }).arguments).toMatchObject([
-        arg('foo bar "baz"')
+        exec('foo bar "baz"')
       ])
       expect(parseCommand(`/Users/My username`).arguments).toMatchObject([
-        arg('/Users/My'),
+        exec('/Users/My'),
         arg('username')
       ])
       expect(parseCommand(`/Users/My\\ username`).arguments).toMatchObject([
-        arg('/Users/My username')
+        exec('/Users/My username')
       ])
       expect(parseCommand(`"/Users/My username"`).arguments).toMatchObject([
-        arg('/Users/My username')
+        exec('/Users/My username')
       ])
     })
     it(`parses nested quotes`, () => {
       expect(parseCommand(`program "level0"`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('level0')
       ])
       expect(parseCommand(`program "level0" "level0" "\\"level1\\""`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('level0'),
         arg('level0'),
         arg('"level1"')
       ])
       expect(parseCommand(`program "level0" "\\"\\\\"level2\\\\"\\""`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('level0'),
         arg('"\\"level2\\""')
       ])
       expect(parseCommand(`program "level0" "\\"'level2'\\""`).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('level0'),
         arg(`"'level2'"`)
       ])
     })
     it(`preserves multiple suffix characters verbatim`, () => {
       expect(parseCommand('a -a=a=b=c').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('a', { isPaired: true, originalValue: '-a=', suffix: '=' }),
         arg('a=b=c')
       ])
       expect(parseCommand('a --asdf=a=b=c').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         longOpt('asdf', { isPaired: true, originalValue: '--asdf=', suffix: '=' }),
         arg('a=b=c')
       ])
       expect(parseCommand('a aa=bb').arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         arg('aa=bb')
       ])
     })
     it(`preserves quotes verbatim when 'preserveQuotes' is true`, () => {
       expect(parseCommand(`program "level0"`, { preserveQuotes: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('"level0"')
       ])
       expect(parseCommand(`program "level0" "level0\\"level1\\""`, { preserveQuotes: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('"level0"'),
         arg('"level0\\"level1\\""')
       ])
       expect(parseCommand(`program "level0" "level0\\"'level2'\\""`, { preserveQuotes: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('"level0"'),
         arg(`"level0\\"'level2'\\""`)
       ])
       expect(parseCommand(`program ""`, { preserveQuotes: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('""')
       ])
       expect(parseCommand(`program "" --asdf=""`, { preserveQuotes: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         arg('""'),
         longOpt('asdf', { suffix: '=', isPaired: true, originalValue: '--asdf=' }),
         arg('""')
@@ -617,25 +621,25 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`preserves combinable options verbatim when 'unpackCombinedOptions' is false`, () => {
       expect(parseCommand('a -something', { unpackCombinedOptions: false }).arguments).toMatchObject([
-        arg('a'),
+        exec('a'),
         shortOpt('something')
       ])
     })
     it(`ignores the options terminator when 'useOptionsTerminator' is false`, () => {
       expect(parseCommand(`program --asdf -- --zxcv`, { useOptionsTerminator: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         longOpt('asdf'),
         arg('--', { isTerminator: true }),
         arg('--zxcv', { afterTerminator: true })
       ])
       expect(parseCommand(`program --asdf -- --zxcv`, { useOptionsTerminator: false }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         longOpt('asdf'),
         arg('--'),
         longOpt('zxcv')
       ])
       expect(parseCommand(`program -abc -- --zxcv`, { useOptionsTerminator: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' }),
@@ -643,7 +647,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--zxcv', { afterTerminator: true })
       ])
       expect(parseCommand(`program -abc -- --zxcv`, { useOptionsTerminator: false }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' }),
@@ -651,7 +655,7 @@ describe(`cmd-tokenize package`, () => {
         longOpt('zxcv')
       ])
       expect(parseCommand(`program -abc -- -zxc`, { useOptionsTerminator: true }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' }),
@@ -659,7 +663,7 @@ describe(`cmd-tokenize package`, () => {
         arg('-zxc', { afterTerminator: true })
       ])
       expect(parseCommand(`program -abc -- -zxc`, { useOptionsTerminator: false }).arguments).toMatchObject([
-        arg('program'),
+        exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' }),
@@ -679,6 +683,7 @@ describe(`cmd-tokenize package`, () => {
       expect(opts1).toStrictEqual({
         useWindowsDelimiters: false,
         unpackCombinedOptions: true,
+        firstIsExec: true,
         preserveQuotes: false,
         useOptionsTerminator: true,
         throwOnUnbalancedQuote: true
@@ -693,6 +698,7 @@ describe(`cmd-tokenize package`, () => {
       expect(opts2).toStrictEqual({
         useWindowsDelimiters: true,
         unpackCombinedOptions: true,
+        firstIsExec: true,
         preserveQuotes: false,
         useOptionsTerminator: true,
         throwOnUnbalancedQuote: true
@@ -703,13 +709,13 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`preserves unbalanced quotes verbatim if not throwing`, () => {
       expect(parseCommand(`command "asdf xcv dfs`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('command'),
+        exec('command'),
         arg(`"asdf`),
         arg(`xcv`),
         arg(`dfs`)
       ])
       expect(parseCommand(`command "asdf\\"xcv dfs`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([
-        arg('command'),
+        exec('command'),
         arg(`"asdf\\"xcv`),
         arg(`dfs`)
       ])
@@ -742,6 +748,50 @@ describe(`cmd-tokenize package`, () => {
       expect(() => parseCommand(`command "asdf xcv dfs`, { throwOnUnbalancedQuote: false })).not.toThrow()
       expect(() => parseCommand(`command "zxcv\\" something`, { throwOnUnbalancedQuote: false })).not.toThrow()
       expect(() => parseCommand(`command \\"zxcv" something`, { throwOnUnbalancedQuote: false })).not.toThrow()
+    })
+    it(`treats the first item in the input as an executable path`, () => {
+      expect(parseCommand(`program not_program`).arguments).toMatchObject([
+        exec('program'),
+        arg('not_program')
+      ])
+      expect(parseCommand(`program not_program`).arguments).not.toMatchObject([
+        arg('program'),
+        exec('not_program')
+      ])
+      expect(parseCommand(`program`).arguments).toMatchObject([
+        exec('program')
+      ])
+      expect(parseCommand(`program`).arguments).not.toMatchObject([
+        arg('program')
+      ])
+      expect(parseCommand(`program`, { firstIsExec: false }).arguments).toMatchObject([
+        arg('program')
+      ])
+      expect(parseCommand(`program`, { firstIsExec: false }).arguments).not.toMatchObject([
+        exec('program')
+      ])
+      expect(parseCommand(`--something --something`).arguments).toMatchObject([
+        exec('--something'),
+        longOpt('something')
+      ])
+      expect(parseCommand(`--something --something`, { firstIsExec: false }).arguments).toMatchObject([
+        longOpt('something'),
+        longOpt('something')
+      ])
+      expect(parseCommand(`-abc -abc`).arguments).toMatchObject([
+        exec('-abc'),
+        shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('c', { originalValue: '-abc', isUnpacked: true })
+      ])
+      expect(parseCommand(`-abc -abc`, { firstIsExec: false }).arguments).toMatchObject([
+        shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('c', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
+        shortOpt('c', { originalValue: '-abc', isUnpacked: true })
+      ])
     })
   })
 })

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,4 +1,4 @@
-const { splitCommand, parseCommand } = require('./index')
+const { splitCommand, parseCommand, splitArguments, parseArguments } = require('./index')
 
 // Returns a parsed argument object's default values.
 const arg = (arg, overrides = {}) => ({ value: arg, prefix: null, prefixType: null, isExecutable: false, isLongOption: false, isOption: false, suffix: null, isPaired: false, isTerminator: false, afterTerminator: false, originalValue: arg, isUnpacked: false, ...overrides })
@@ -791,6 +791,36 @@ describe(`cmd-tokenize package`, () => {
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('c', { originalValue: '-abc', isUnpacked: true })
+      ])
+    })
+  })
+  describe(`splitArguments()`, () => {
+    it(`returns the result of splitCommand() with 'firstIsExec' set to false`, () => {
+      expect(splitArguments('something')).toStrictEqual(['something'])
+      expect(splitArguments('-abc -a')).toStrictEqual(['-a', '-b', '-c', '-a'])
+      expect(splitArguments('-abc -a -b')).toStrictEqual(['-a', '-b', '-c', '-a', '-b'])
+    })
+  })
+  describe(`parseArguments()`, () => {
+    it(`returns the result of parseCommand() with 'firstIsExec' set to false`, () => {
+      const res = parseArguments('run_program')
+      const opts = { ...res.options }
+      delete opts.format
+      expect(opts).toStrictEqual({
+        useWindowsDelimiters: false,
+        unpackCombinedOptions: true,
+        firstIsExec: false,
+        preserveQuotes: false,
+        useOptionsTerminator: true,
+        throwOnUnbalancedQuote: true
+      })
+      expect(parseArguments(`not_program also_not_program`).arguments).toMatchObject([
+        arg('not_program'),
+        arg('also_not_program')
+      ])
+      expect(parseArguments(`--arg --arg2`).arguments).toMatchObject([
+        longOpt('arg'),
+        longOpt('arg2')
       ])
     })
   })

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,3 +1,6 @@
+// cmd-tokenize <https://github.com/msikma/cmd-tokenize>
+// © MIT license
+
 const { splitCommand, parseCommand, splitArguments, parseArguments } = require('./index')
 
 // Returns a parsed argument object's default values.
@@ -14,9 +17,9 @@ describe(`cmd-tokenize package`, () => {
       expect(splitCommand('run_program -a')).toStrictEqual(['run_program', '-a'])
       expect(splitCommand('run_program -a -b')).toStrictEqual(['run_program', '-a', '-b'])
     })
-    it(`unpacks combinable short options`, () => {
-      expect(splitCommand('run_program -abc')).toStrictEqual(['run_program', '-a', '-b', '-c'])
-      expect(splitCommand('run_program -abc -- -abc')).toStrictEqual(['run_program', '-a', '-b', '-c', '--', '-abc'])
+    it(`unpacks combinable short options if 'unpackCombinedOptions' is true`, () => {
+      expect(splitCommand('run_program -abc', { unpackCombinedOptions: true })).toStrictEqual(['run_program', '-a', '-b', '-c'])
+      expect(splitCommand('run_program -abc -- -abc', { unpackCombinedOptions: true })).toStrictEqual(['run_program', '-a', '-b', '-c', '--', '-abc'])
     })
     it(`throws when anything other than a string is passed as argument`, () => {
       expect(() => splitCommand(1)).toThrow()
@@ -52,7 +55,7 @@ describe(`cmd-tokenize package`, () => {
         ],
         options: {}
       })
-      expect(parseCommand(`run_program hello world "hello world" -a -a -b -b --a sadf  -n asdf  --some_value="something" --another-value="some thing" --yet_another_value="a  \\"quoted value\\""  --a --b --z="dsf" -asdf --d=\\"sdf\\" --d = - -- --zap --sdf`).arguments).toMatchObject([
+      expect(parseCommand(`run_program hello world "hello world" -a -a -b -b --a sadf  -n asdf  --some_value="something" --another-value="some thing" --yet_another_value="a  \\"quoted value\\""  --a --b --z="dsf" -asdf --d=\\"sdf\\" --d = - -- --zap --sdf`, { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('run_program'),
         arg('hello'),
         arg('world'),
@@ -96,7 +99,7 @@ describe(`cmd-tokenize package`, () => {
         arg(' zxcv '),
         arg(` qwer" wer " `)
       ])
-      expect(parseCommand(`program arg --another-arg -a -asdf --with-value="value" -- --after-terminator`).arguments).toMatchObject([
+      expect(parseCommand(`program arg --another-arg -a -asdf --with-value="value" -- --after-terminator`, { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('program'),
         arg('arg'),
         longOpt('another-arg'),
@@ -110,7 +113,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--', { isTerminator: true }),
         arg('--after-terminator', { afterTerminator: true })
       ])
-      expect(parseCommand(`run_program arg "another arg" "an arg with \\"nested and \\\\"super nested\\\\" quotes\\"" --a --b -asdf --z="hello" --empty="" -a="b" -abc="d" - = --quotes="quotes 'inner \\"more inner quotes\\" quotes'" -- --post-terminator -asdf -a -b`).arguments).toMatchObject([
+      expect(parseCommand(`run_program arg "another arg" "an arg with \\"nested and \\\\"super nested\\\\" quotes\\"" --a --b -asdf --z="hello" --empty="" -a="b" -abc="d" - = --quotes="quotes 'inner \\"more inner quotes\\" quotes'" -- --post-terminator -asdf -a -b`, { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('run_program'),
         arg('arg'),
         arg('another arg'),
@@ -367,13 +370,13 @@ describe(`cmd-tokenize package`, () => {
       ])
     })
     it(`preserves arguments enclosed in double quotes verbatim`, () => {
-      expect(parseCommand('a -abc').arguments).toMatchObject([
+      expect(parseCommand('a -abc', { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('c', { isUnpacked: true, originalValue: '-abc' })
       ])
-      expect(parseCommand('a "-abc"').arguments).toMatchObject([
+      expect(parseCommand('a "-abc"', { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
@@ -405,7 +408,7 @@ describe(`cmd-tokenize package`, () => {
       ])
     })
     it(`parses Windows style options when 'useWindowsDelimiters' is true`, () => {
-      expect(parseCommand('a /aaa /c /d /zxcv', { useWindowsDelimiters: true }).arguments).toMatchObject([
+      expect(parseCommand('a /aaa /c /d /zxcv', { useWindowsDelimiters: true, unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
@@ -452,7 +455,7 @@ describe(`cmd-tokenize package`, () => {
       ])
     })
     it(`unpacks short arguments`, () => {
-      expect(parseCommand('a -a -bc -def').arguments).toMatchObject([
+      expect(parseCommand('a -a -bc -def', { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOpt('a'),
         shortOpt('b', { originalValue: '-bc', isUnpacked: true }),
@@ -461,7 +464,7 @@ describe(`cmd-tokenize package`, () => {
         shortOpt('e', { originalValue: '-def', isUnpacked: true }),
         shortOpt('f', { originalValue: '-def', isUnpacked: true })
       ])
-      expect(parseCommand('a --a -abc --d').arguments).toMatchObject([
+      expect(parseCommand('a --a -abc --d', { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         longOpt('a'),
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
@@ -469,14 +472,14 @@ describe(`cmd-tokenize package`, () => {
         shortOpt('c', { originalValue: '-abc', isUnpacked: true }),
         longOpt('d')
       ])
-      expect(parseCommand('a -abc="d"').arguments).toMatchObject([
+      expect(parseCommand('a -abc="d"', { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOpt('a', { originalValue: '-abc=', suffix: '=', isPaired: false, isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc=', suffix: '=', isPaired: false, isUnpacked: true }),
         shortOpt('c', { originalValue: '-abc=', suffix: '=', isPaired: true, isUnpacked: true }),
         arg('d')
       ])
-      expect(parseCommand('a -abc -- -abc').arguments).toMatchObject([
+      expect(parseCommand('a -abc -- -abc', { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
@@ -484,7 +487,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--', { isTerminator: true }),
         arg('-abc', { afterTerminator: true })
       ])
-      expect(parseCommand(`a  -abcd="z"   --a -- -zxcv`).arguments).toMatchObject([
+      expect(parseCommand(`a  -abcd="z"   --a -- -zxcv`, { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('a'),
         shortOpt('a', { originalValue: '-abcd=', isUnpacked: true, suffix: '=' }),
         shortOpt('b', { originalValue: '-abcd=', isUnpacked: true, suffix: '=' }),
@@ -638,7 +641,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--'),
         longOpt('zxcv')
       ])
-      expect(parseCommand(`program -abc -- --zxcv`, { useOptionsTerminator: true }).arguments).toMatchObject([
+      expect(parseCommand(`program -abc -- --zxcv`, { useOptionsTerminator: true, unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
@@ -646,7 +649,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--', { isTerminator: true }),
         arg('--zxcv', { afterTerminator: true })
       ])
-      expect(parseCommand(`program -abc -- --zxcv`, { useOptionsTerminator: false }).arguments).toMatchObject([
+      expect(parseCommand(`program -abc -- --zxcv`, { useOptionsTerminator: false, unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
@@ -654,7 +657,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--'),
         longOpt('zxcv')
       ])
-      expect(parseCommand(`program -abc -- -zxc`, { useOptionsTerminator: true }).arguments).toMatchObject([
+      expect(parseCommand(`program -abc -- -zxc`, { useOptionsTerminator: true, unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
@@ -662,7 +665,7 @@ describe(`cmd-tokenize package`, () => {
         arg('--', { isTerminator: true }),
         arg('-zxc', { afterTerminator: true })
       ])
-      expect(parseCommand(`program -abc -- -zxc`, { useOptionsTerminator: false }).arguments).toMatchObject([
+      expect(parseCommand(`program -abc -- -zxc`, { useOptionsTerminator: false, unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('program'),
         shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
         shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
@@ -682,7 +685,7 @@ describe(`cmd-tokenize package`, () => {
       delete opts1.format
       expect(opts1).toStrictEqual({
         useWindowsDelimiters: false,
-        unpackCombinedOptions: true,
+        unpackCombinedOptions: false,
         firstIsExec: true,
         preserveQuotes: false,
         useOptionsTerminator: true,
@@ -697,7 +700,7 @@ describe(`cmd-tokenize package`, () => {
       delete opts2.format
       expect(opts2).toStrictEqual({
         useWindowsDelimiters: true,
-        unpackCombinedOptions: true,
+        unpackCombinedOptions: false,
         firstIsExec: true,
         preserveQuotes: false,
         useOptionsTerminator: true,
@@ -778,13 +781,13 @@ describe(`cmd-tokenize package`, () => {
         longOpt('something'),
         longOpt('something')
       ])
-      expect(parseCommand(`-abc -abc`).arguments).toMatchObject([
+      expect(parseCommand(`-abc -abc`, { unpackCombinedOptions: true }).arguments).toMatchObject([
         exec('-abc'),
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('c', { originalValue: '-abc', isUnpacked: true })
       ])
-      expect(parseCommand(`-abc -abc`, { firstIsExec: false }).arguments).toMatchObject([
+      expect(parseCommand(`-abc -abc`, { firstIsExec: false, unpackCombinedOptions: true }).arguments).toMatchObject([
         shortOpt('a', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('b', { originalValue: '-abc', isUnpacked: true }),
         shortOpt('c', { originalValue: '-abc', isUnpacked: true }),
@@ -797,8 +800,8 @@ describe(`cmd-tokenize package`, () => {
   describe(`splitArguments()`, () => {
     it(`returns the result of splitCommand() with 'firstIsExec' set to false`, () => {
       expect(splitArguments('something')).toStrictEqual(['something'])
-      expect(splitArguments('-abc -a')).toStrictEqual(['-a', '-b', '-c', '-a'])
-      expect(splitArguments('-abc -a -b')).toStrictEqual(['-a', '-b', '-c', '-a', '-b'])
+      expect(splitArguments('-abc -a', { unpackCombinedOptions: true })).toStrictEqual(['-a', '-b', '-c', '-a'])
+      expect(splitArguments('-abc -a -b', { unpackCombinedOptions: true })).toStrictEqual(['-a', '-b', '-c', '-a', '-b'])
     })
   })
   describe(`parseArguments()`, () => {
@@ -808,7 +811,7 @@ describe(`cmd-tokenize package`, () => {
       delete opts.format
       expect(opts).toStrictEqual({
         useWindowsDelimiters: false,
-        unpackCombinedOptions: true,
+        unpackCombinedOptions: false,
         firstIsExec: false,
         preserveQuotes: false,
         useOptionsTerminator: true,

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -362,6 +362,44 @@ describe(`cmd-tokenize package`, () => {
         arg('asdf=zxcv')
       ])
     })
+    it(`preserves arguments enclosed in double quotes verbatim`, () => {
+      expect(parseCommand('a -abc').arguments).toMatchObject([
+        arg('a'),
+        shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
+        shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
+        shortOpt('c', { isUnpacked: true, originalValue: '-abc' })
+      ])
+      expect(parseCommand('a "-abc"').arguments).toMatchObject([
+        arg('a'),
+        shortOpt('a', { isUnpacked: true, originalValue: '-abc' }),
+        shortOpt('b', { isUnpacked: true, originalValue: '-abc' }),
+        shortOpt('c', { isUnpacked: true, originalValue: '-abc' })
+      ])
+      expect(parseCommand(`a "'-abc'"`).arguments).toMatchObject([
+        arg('a'),
+        arg(`'-abc'`)
+      ])
+      expect(parseCommand(`a '"-abc"'`).arguments).toMatchObject([
+        arg('a'),
+        arg(`"-abc"`)
+      ])
+      expect(parseCommand(`a --hello`).arguments).toMatchObject([
+        arg('a'),
+        longOpt(`hello`)
+      ])
+      expect(parseCommand(`a "--hello"`).arguments).toMatchObject([
+        arg('a'),
+        longOpt(`hello`)
+      ])
+      expect(parseCommand(`a "'--hello'"`).arguments).toMatchObject([
+        arg('a'),
+        arg(`'--hello'`)
+      ])
+      expect(parseCommand(`a '"--hello"'`).arguments).toMatchObject([
+        arg('a'),
+        arg(`"--hello"`)
+      ])
+    })
     it(`parses Windows style options when 'useWindowsDelimiters' is true`, () => {
       expect(parseCommand('a /aaa /c /d /zxcv', { useWindowsDelimiters: true }).arguments).toMatchObject([
         arg('a'),

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -522,6 +522,35 @@ describe(`cmd-tokenize package`, () => {
         arg(' "z" ')
       ])
     })
+    it(`preserves escaped spaces outside of quotes`, () => {
+      expect(parseCommand(`foo\\ bar baz`).arguments).toMatchObject([
+        arg('foo bar'),
+        arg('baz')
+      ])
+      expect(parseCommand(`foo\\ bar\\ baz`).arguments).toMatchObject([
+        arg('foo bar baz')
+      ])
+      expect(parseCommand(`foo\\ bar\\ baz bap`).arguments).toMatchObject([
+        arg('foo bar baz'),
+        arg('bap')
+      ])
+      expect(parseCommand(`foo\\ bar\\ "baz"`).arguments).toMatchObject([
+        arg('foo bar baz')
+      ])
+      expect(parseCommand(`foo\\ bar\\ "baz"`, { preserveQuotes: true }).arguments).toMatchObject([
+        arg('foo bar "baz"')
+      ])
+      expect(parseCommand(`/Users/My username`).arguments).toMatchObject([
+        arg('/Users/My'),
+        arg('username')
+      ])
+      expect(parseCommand(`/Users/My\\ username`).arguments).toMatchObject([
+        arg('/Users/My username')
+      ])
+      expect(parseCommand(`"/Users/My username"`).arguments).toMatchObject([
+        arg('/Users/My username')
+      ])
+    })
     it(`parses nested quotes`, () => {
       expect(parseCommand(`program "level0"`).arguments).toMatchObject([
         arg('program'),

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -362,8 +362,8 @@ describe(`cmd-tokenize package`, () => {
         arg('asdf=zxcv')
       ])
     })
-    it(`parses Windows style options`, () => {
-      expect(parseCommand('a /aaa /c /d /zxcv').arguments).toMatchObject([
+    it(`parses Windows style options when 'useWindowsDelimiters' is true`, () => {
+      expect(parseCommand('a /aaa /c /d /zxcv', { useWindowsDelimiters: true }).arguments).toMatchObject([
         arg('a'),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
         shortOptW('a', { originalValue: '/aaa', isUnpacked: true }),
@@ -606,19 +606,33 @@ describe(`cmd-tokenize package`, () => {
       expect(parseCommand('run_program').inputSplit).toStrictEqual(splitCommand('run_program'))
     })
     it(`contains the expected default options`, () => {
-      const res = parseCommand('run_program')
-      const opts = { ...res.options }
-      delete opts.format
-      expect(opts).toStrictEqual({
+      const res1 = parseCommand('run_program')
+      const opts1 = { ...res1.options }
+      delete opts1.format
+      expect(opts1).toStrictEqual({
         useWindowsDelimiters: false,
         unpackCombinedOptions: true,
         preserveQuotes: false,
         useOptionsTerminator: true,
         throwOnUnbalancedQuote: true
       })
-      expect(res.options.format.valuePrefix).toMatchObject([{ type: 'unix' }, { type: 'windows' }])
-      expect(res.options.format.valueSuffix).toMatchObject(['=', ':'])
-      expect(res.options.format.optionsTerminator).toBe('--')
+      expect(res1.options.format.valuePrefix).toMatchObject([{ type: 'unix' }])
+      expect(res1.options.format.valueSuffix).toMatchObject(['=', ':'])
+      expect(res1.options.format.optionsTerminator).toBe('--')
+
+      const res2 = parseCommand('run_program /a', { useWindowsDelimiters: true })
+      const opts2 = { ...res2.options }
+      delete opts2.format
+      expect(opts2).toStrictEqual({
+        useWindowsDelimiters: true,
+        unpackCombinedOptions: true,
+        preserveQuotes: false,
+        useOptionsTerminator: true,
+        throwOnUnbalancedQuote: true
+      })
+      expect(res2.options.format.valuePrefix).toMatchObject([{ type: 'windows' }])
+      expect(res2.options.format.valueSuffix).toMatchObject(['=', ':'])
+      expect(res2.options.format.optionsTerminator).toBe('--')
     })
     it(`preserves unbalanced quotes verbatim if not throwing`, () => {
       expect(parseCommand(`command "asdf xcv dfs`, { throwOnUnbalancedQuote: false }).arguments).toMatchObject([

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -607,7 +607,10 @@ describe(`cmd-tokenize package`, () => {
     })
     it(`contains the expected default options`, () => {
       const res = parseCommand('run_program')
-      expect(res.options).toMatchObject({
+      const opts = { ...res.options }
+      delete opts.format
+      expect(opts).toStrictEqual({
+        useWindowsDelimiters: false,
         unpackCombinedOptions: true,
         preserveQuotes: false,
         useOptionsTerminator: true,

--- a/lib/split/index.js
+++ b/lib/split/index.js
@@ -1,7 +1,7 @@
 // cmd-tokenize <https://github.com/msikma/cmd-tokenize>
 // © MIT license
 
-const { splitNestedQuotes, handleSeparators, reduceQuoteDepth, removeWhitespace, mergeConsecutiveArguments, removeEmptyStrings, flattenNestedQuotes } = require('./quotes')
+const { splitNestedQuotes, handleSeparators, reduceQuoteDepth, removeWhitespace, mergeConsecutiveArguments, removeEmptyStrings, flattenNestedQuotes, combineEscapedSpaces } = require('./quotes')
 
 /**
  * Splits up a command into argument pieces that can be processed one by one.
@@ -12,6 +12,7 @@ const { splitNestedQuotes, handleSeparators, reduceQuoteDepth, removeWhitespace,
  */
 const splitIntoArguments = (str, options, format) => {
   let parsed = splitNestedQuotes(str, options.throwOnUnbalancedQuote)
+  parsed = combineEscapedSpaces(parsed, options.preserveQuotes)
   parsed = reduceQuoteDepth(parsed, options.preserveQuotes ? 0 : 1, null)
   parsed = flattenNestedQuotes(parsed)
   parsed = mergeConsecutiveArguments(parsed, options, format)
@@ -35,6 +36,7 @@ const splitIntoArguments = (str, options, format) => {
  */
 const parseNestedQuotes = (str, keepWhitespace = false) => {
   let parsed = splitNestedQuotes(str)
+  parsed = combineEscapedSpaces(parsed, options.preserveQuotes)
   parsed = reduceQuoteDepth(parsed, Infinity, null)
   parsed = removeEmptyStrings(parsed, keepWhitespace)
   return parsed

--- a/lib/split/quotes.js
+++ b/lib/split/quotes.js
@@ -250,7 +250,75 @@ const mergeConsecutiveArguments = (flatItems, options, format) => {
   return items
 }
 
+/**
+ * Returns whether an argument ends on an escape character.
+ */
+const hasEscapeEnd = (item) => {
+  const hasEscape = item.slice(-1) === '\\'
+  return [hasEscape, hasEscape ? item.slice(0, -1) : item]
+}
 
+/**
+ * Combines items that are separated by an escaped space.
+ * 
+ * Normally all items are always split by space, with the spaces being preserved
+ * only for items in quotation marks. However, it's also possible to have arguments
+ * with spaces in them by escaping the space character, e.g. hello\ world.
+ * 
+ * Items with escaped spaces have been split up at this point, and this function
+ * puts them back together and removes the escape slash. Note that this should only
+ * occur for depth -1, as spaces and slashes inside quotes are already preserved.
+ */
+const combineEscapedSpaces = (nestedItems, preserveQuotes) => {
+  const items = []
+  let hasEscape, itemClean = null
+  let combined = []
+  let toCombine = 0
+
+  for (const item of nestedItems) {
+    if (isString(item)) {
+      [hasEscape, itemClean] = hasEscapeEnd(item)
+      if (hasEscape) {
+        toCombine = 2
+        combined.push(itemClean)
+        continue
+      }
+      if (toCombine > 0) {
+        toCombine -= 1
+        combined.push(item)
+        continue
+      }
+      if (toCombine === 0) {
+        if (combined.length) {
+          items.push(combined.join(''))
+          combined = []
+        }
+        items.push(item)
+        continue
+      }
+    }
+    if (isArray(item)) {
+      if (toCombine > 0) {
+        toCombine -= 1
+        combined.push(reduceQuoteDepth([item], preserveQuotes ? 0 : 1).flat().join(''))
+        continue
+      }
+      if (toCombine === 0) {
+        if (combined.length) {
+          items.push(combined.join(''))
+          combined = []
+        }
+        items.push(item)
+        continue
+      }
+    }
+  }
+  if (combined.length) {
+    items.push(combined.join(''))
+    combined = []
+  }
+  return items
+}
 
 /**
  * Modifies the split items to handle arguments with separators (suffixes).
@@ -340,6 +408,7 @@ module.exports = {
   handleSeparators,
   removeEmptyStrings,
   mergeConsecutiveArguments,
+  combineEscapedSpaces,
   splitNestedQuotes,
   removeWhitespace
 }

--- a/lib/split/quotes.js
+++ b/lib/split/quotes.js
@@ -334,14 +334,17 @@ const handleSeparators = (flatItems, options, format) => {
 
   // Only arguments not inside quotes can be split up; if they're quoted,
   // the values are literal.
-  for (const item of flatItems) {
+  for (let n = 0; n < flatItems.length; ++n) {
+    const item = flatItems[n]
+    const isExec = n === 0 && options.firstIsExec
+    
     // There shouldn't be any arrays in here, though...
     if (!isString(item) || isWhitespace(item)) {
       items.push(item)
       continue
     }
 
-    const isTerminator = findTerminator(item, format.optionsTerminator, afterTerminator, options.useOptionsTerminator)
+    const isTerminator = findTerminator(item, format.optionsTerminator, isExec, afterTerminator, options.useOptionsTerminator)
     const isOption = argumentIsOption(item, format, isTerminator || afterTerminator)
     
     afterTerminator ||= isTerminator

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cmd-tokenize",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cmd-tokenize",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "jest": "^27.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmd-tokenize",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Library for converting terminal command strings into an easy to process format",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ console.log(parsed)
 //       prefix: null,
 //       prefixType: null,
 //       suffix: null,
+//       isExecutable: true,
 //       isOption: false,
 //       isLongOption: false,
 //       isPaired: false,
@@ -53,6 +54,7 @@ For both these functions, the following options can be passed in an object as th
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| firstIsExec | boolean | true | Treats the first item as the path to the executable |
 | preserveQuotes | boolean | false | Causes quotation marks around arguments to be preserved exactly |
 | throwOnUnbalancedQuote | boolean | true | Throws an error when unbalanced quotes are encounted, e.g. `"some argument` |
 | unpackCombinedOptions | boolean | true | Transforms combined options into individual options; an argument like `-asdf` becomes `-a`, `-s`, `-d`, `-f` |
@@ -62,6 +64,8 @@ For both these functions, the following options can be passed in an object as th
 In standard argument parsers, multiple short options such as `-a` may be combined into a single token; if this is not desirable, the `unpackCombinedOptions` should be set to true. This is useful if your parser does not distinguish between short and long options (one notable example is `ffmpeg`, which uses a single dash for both short and long options).
 
 The `useWindowsDelimiters` option should be set to true when writing a parser for commands with Windows style slash arguments, such as `program.exe /a /b /c`. These are fundamentally incompatible with Unix style paths, which are now being used on Windows as well (per the introduction of the [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)), so it's recommended that you *always* use Unix style arguments regardless of what platform you're writing for. Note that, if you do parse Windows style slash arguments, you should also set `useOptionsTerminator` to false as this is not a convention used on Windows.
+
+The `firstIsExec` option ensures that the first item is parsed correctly if it's the name of the executable (e.g. the `ls` in `ls -lah`); technically an executable file can be named `--something`, which should not be parsed as an argument if it is the executable name. If you're *only* parsing arguments without an executable name, use `parseArguments()` instead of `parseCommand()`.
 
 ### Argument metadata
 
@@ -73,9 +77,10 @@ After parsing, each argument will have the following metadata:
 | prefix | string&nbsp;\|&nbsp;null | Prefix delimiter, if present; `"--"` for `--foo` |
 | prefixType | string&nbsp;\|&nbsp;null | Either `"unix"` or `"windows"` depending on whether the delimiter was a `-` dash or `/` slash |
 | suffix | string&nbsp;\|&nbsp;null | Suffix delimiter, if present; `"="` for `--foo="bar"` |
+| isExecutable | boolean | Whether this argument is the executable (the first item); true for `mkdir` in the command `mkdir -p /some/path`, false for the rest of the items |
 | isOption | boolean | Whether this argument is an option; true for `-f` or `--foo`, false for `foo` |
 | isLongOption | boolean | Whether this argument's option is a double hyphens; false for `-f`, true for `--foo` |
-| isPaired | boolean | Whether this argument pairs with the next argument as its value; for `--foo="bar"`, the `foo` object pairs with the `bar` object that comes directly after it. |
+| isPaired | boolean | Whether this argument pairs with the next argument as its value; for `--foo="bar"`, the `foo` item pairs with the `bar` item that comes directly after it |
 | isTerminator | boolean | Whether this is the `"--"` terminator argument—[see the syntax conventions section on Argon's readme page](https://github.com/msikma/argon#syntax-conventions) |
 | isUnpacked | boolean | Whether this argument is a split up combination argument; an argument like `-asdf` becomes `-a`, `-s`, `-d`, `-f` |
 | afterTerminator | boolean | Whether this argument came after the terminator |

--- a/readme.md
+++ b/readme.md
@@ -57,11 +57,11 @@ For both these functions, the following options can be passed in an object as th
 | firstIsExec | boolean | true | Treats the first item as the path to the executable |
 | preserveQuotes | boolean | false | Causes quotation marks around arguments to be preserved exactly |
 | throwOnUnbalancedQuote | boolean | true | Throws an error when unbalanced quotes are encounted, e.g. `"some argument` |
-| unpackCombinedOptions | boolean | true | Transforms combined options into individual options; an argument like `-asdf` becomes `-a`, `-s`, `-d`, `-f` |
+| unpackCombinedOptions | boolean | false | Breaks up combined options into individual options; an argument like `-asdf` becomes `-a`, `-s`, `-d`, `-f` |
 | useOptionsTerminator | boolean | true | Whether to look for the `--` terminator, which causes subsequent arguments to be treated verbatim |
 | useWindowsDelimiters | boolean | false | Searches for Windows style slash delimiters rather than Unix style dash delimiters (never recommended even on Windows) |
 
-In standard argument parsers, multiple short options such as `-a` may be combined into a single token; if this is not desirable, the `unpackCombinedOptions` should be set to true. This is useful if your parser does not distinguish between short and long options (one notable example is `ffmpeg`, which uses a single dash for both short and long options).
+In standard argument parsers, multiple short options such as `-a` may be combined into a single token, like `ls -lah` being equivalent to `ls -l -a -h`; these can be broken up for easier processing by setting `unpackCombinedOptions` to true. Conversely, if your parser does not distinguish between short and long options (one notable example being `ffmpeg`, which uses a single dash for both short and long options) you should leave it at its default of false.
 
 The `useWindowsDelimiters` option should be set to true when writing a parser for commands with Windows style slash arguments, such as `program.exe /a /b /c`. These are fundamentally incompatible with Unix style paths, which are now being used on Windows as well (per the introduction of the [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)), so it's recommended that you *always* use Unix style arguments regardless of what platform you're writing for. Note that, if you do parse Windows style slash arguments, you should also set `useOptionsTerminator` to false as this is not a convention used on Windows.
 

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ console.log(parsed)
 //     ...
 ```
 
-Arguments are split by whitespace, with quoted sections remaining preserved. Both Unix and Windows style delimiters (dash and backslash) are supported.
+Arguments are split by whitespace, with quoted sections remaining preserved. Both Unix and Windows style delimiters (dash and slash) are supported.
 
 If you want to process the arguments manually and just need them split up, you can do so using `splitCommand()`.
 
@@ -53,12 +53,15 @@ For both these functions, the following options can be passed in an object as th
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| unpackCombinedOptions | boolean | true | Transforms combined options into individual options; an argument like `-asdf` becomes `-a`, `-s`, `-d`, `-f` |
 | preserveQuotes | boolean | false | Causes quotation marks around arguments to be preserved exactly |
-| useOptionsTerminator | boolean | true | Whether to look for the `--` terminator, which causes subsequent arguments to be treated verbatim |
 | throwOnUnbalancedQuote | boolean | true | Throws an error when unbalanced quotes are encounted, e.g. `"some argument` |
+| unpackCombinedOptions | boolean | true | Transforms combined options into individual options; an argument like `-asdf` becomes `-a`, `-s`, `-d`, `-f` |
+| useOptionsTerminator | boolean | true | Whether to look for the `--` terminator, which causes subsequent arguments to be treated verbatim |
+| useWindowsDelimiters | boolean | false | Searches for Windows style slash delimiters rather than Unix style dash delimiters (never recommended even on Windows) |
 
 In standard argument parsers, multiple short options such as `-a` may be combined into a single token; if this is not desirable, the `unpackCombinedOptions` should be set to true. This is useful if your parser does not distinguish between short and long options (one notable example is `ffmpeg`, which uses a single dash for both short and long options).
+
+The `useWindowsDelimiters` option should be set to true when writing a parser for commands with Windows style slash arguments, such as `program.exe /a /b /c`. These are fundamentally incompatible with Unix style paths, which are now being used on Windows as well (per the introduction of the [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)), so it's recommended that you *always* use Unix style arguments regardless of what platform you're writing for.
 
 ### Argument metadata
 
@@ -68,7 +71,7 @@ After parsing, each argument will have the following metadata:
 |:-----|:-----|:------------|
 | value | string | String content of the argument with all delimiters stripped; `"foo"` for `--foo` |
 | prefix | string&nbsp;\|&nbsp;null | Prefix delimiter, if present; `"--"` for `--foo` |
-| prefixType | string&nbsp;\|&nbsp;null | Either `"unix"` or `"windows"` depending on whether the delimiter was a dash or backslash |
+| prefixType | string&nbsp;\|&nbsp;null | Either `"unix"` or `"windows"` depending on whether the delimiter was a `-` dash or `/` slash |
 | suffix | string&nbsp;\|&nbsp;null | Suffix delimiter, if present; `"="` for `--foo="bar"` |
 | isOption | boolean | Whether this argument is an option; true for `-f` or `--foo`, false for `foo` |
 | isLongOption | boolean | Whether this argument's option is a double hyphens; false for `-f`, true for `--foo` |

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ For both these functions, the following options can be passed in an object as th
 
 In standard argument parsers, multiple short options such as `-a` may be combined into a single token; if this is not desirable, the `unpackCombinedOptions` should be set to true. This is useful if your parser does not distinguish between short and long options (one notable example is `ffmpeg`, which uses a single dash for both short and long options).
 
-The `useWindowsDelimiters` option should be set to true when writing a parser for commands with Windows style slash arguments, such as `program.exe /a /b /c`. These are fundamentally incompatible with Unix style paths, which are now being used on Windows as well (per the introduction of the [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)), so it's recommended that you *always* use Unix style arguments regardless of what platform you're writing for.
+The `useWindowsDelimiters` option should be set to true when writing a parser for commands with Windows style slash arguments, such as `program.exe /a /b /c`. These are fundamentally incompatible with Unix style paths, which are now being used on Windows as well (per the introduction of the [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)), so it's recommended that you *always* use Unix style arguments regardless of what platform you're writing for. Note that, if you do parse Windows style slash arguments, you should also set `useOptionsTerminator` to false as this is not a convention used on Windows.
 
 ### Argument metadata
 


### PR DESCRIPTION
This solves some edge cases with escaped spaces too.